### PR TITLE
Create a header for x.c, add fallback colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This is my personal fork of the [Suckless simple terminal](https://st.suckless.o
 * [Scrollback + Mouse](https://st.suckless.org/patches/scrollback/)
 * Xresources support - automatically reads and applies on startup
 
+The colors specified in config.h are only the fallback colors, they will be replaced by Xresources.
+

--- a/config.def.h
+++ b/config.def.h
@@ -7,6 +7,7 @@
  */
 static char *font = "Monospace:pixelsize=12:antialias=true:autohint=true";
 static int borderpx = 2;
+static int alpha = 0xcc;
 
 /*
  * What program is execed by st depends of these precedence rules:

--- a/config.h
+++ b/config.h
@@ -89,27 +89,28 @@ char *termname = "st-256color";
 */
 unsigned int tabspaces = 4;
 
-/* Terminal colors (16 first used in escape sequence) */
+/* Terminal default colors (16 first used in escape sequence)
+ * Used as fallback in case Xresources don't load */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#202020",     // black
-	"#e17d4a",     // red
-	"#8bb165",     // green
-	"#bfb65c",     // yellow
-	"#539d9f",     // blue
-	"#9f595b",     // magenta
-	"#8d987e",     // cyan
-	"#c9b18b",     // white
+	"#000000",     // black
+	"#ce0f0f",     // red
+	"#20db27",     // green
+	"#dddf10",     // yellow
+	"#1054cb",     // blue
+	"#903089",     // magenta
+	"#10dfdf",     // cyan
+	"#dfdfdf",     // white
 
 	/* 8 bright colors */
-	"#202020",     // black
-	"#e48c4a",     // red
-	"#8cb969",     // green
-	"#bfb640",     // yellow
-	"#529b9e",     // blue
-	"#80585a",     // magenta
-	"#889c79",     // cyan
-	"#978965",     // white
+	"#101010",     // black
+	"#de1212",     // red
+	"#20db27",     // green
+	"#edea14",     // yellow
+	"#1b64db",     // blue
+	"#a03099",     // magenta
+	"#14efef",     // cyan
+	"#efefef",     // white
 
 	[255] = 0,
 

--- a/x.c
+++ b/x.c
@@ -20,6 +20,7 @@ static char *argv0;
 #include "arg.h"
 #include "st.h"
 #include "win.h"
+#include "x.h"
 
 /* types used in config.h */
 typedef struct {
@@ -56,14 +57,6 @@ typedef struct {
 	void *dst;
 } ResourcePref;
 
-/* X modifiers */
-#define XK_ANY_MOD    UINT_MAX
-#define XK_NO_MOD     0
-#define XK_SWITCH_MOD (1<<13)
-
-#define OPAQUE 0Xff
-#define USE_ARGB (alpha != OPAQUE && opt_embed == NULL)
-
 /* function definitions used in config.h */
 static void clipcopy(const Arg *);
 static void clippaste(const Arg *);
@@ -75,19 +68,6 @@ static void zoomreset(const Arg *);
 
 /* config.h for applying patches and the configuration. */
 #include "config.h"
-
-/* XEMBED messages */
-#define XEMBED_FOCUS_IN  4
-#define XEMBED_FOCUS_OUT 5
-
-/* macros */
-#ifdef IS_SET
-#undef IS_SET
-#endif
-#define IS_SET(flag)		((win.mode & (flag)) != 0)
-#define TRUERED(x)		(((x) & 0xff0000) >> 8)
-#define TRUEGREEN(x)		(((x) & 0xff00))
-#define TRUEBLUE(x)		(((x) & 0xff) << 8)
 
 typedef XftDraw *Draw;
 typedef XftColor Color;

--- a/x.h
+++ b/x.h
@@ -1,0 +1,20 @@
+/* X modifiers */
+#define XK_ANY_MOD    UINT_MAX
+#define XK_NO_MOD     0
+#define XK_SWITCH_MOD (1<<13)
+
+#define OPAQUE 0xff
+#define USE_ARGB (alpha != OPAQUE && opt_embed == NULL)
+
+/* XEMBED messages */
+#define XEMBED_FOCUS_IN  4
+#define XEMBED_FOCUS_OUT 5
+
+#ifdef IS_SET
+#undef IS_SET
+#endif
+#define IS_SET(flag)     ((win.mode & (flag)) != 0)
+#define TRUERED(x)       (((x) & 0xff0000) >> 8)
+#define TRUEGREEN(x)     (((x) & 0xff00))
+#define TRUEBLUE(x)      (((x) & 0xff) << 8)
+


### PR DESCRIPTION
Now the colors in config.h are only used if none are supplied via Xresources. This sets them to neutral, default colors instead of personal preference ones